### PR TITLE
refactor: use ESM import for yt-dlp-wrap

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -9,7 +9,7 @@ import {
 } from "@shared/schema";
 import fetch from 'node-fetch';
 import OpenAI from "openai";
-import YTDlpWrap from 'yt-dlp-wrap';
+import YTDlpWrap from "yt-dlp-wrap";
 
 const openai = new OpenAI({ 
   apiKey: process.env.OPENAI_API_KEY || process.env.OPENAI_API_KEY_ENV_VAR || ""
@@ -156,8 +156,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
       try {
         console.log('Fetching transcript for video ID:', videoId);
         
-        // Initialize yt-dlp-wrap  
-        const ytDlp = new (require('yt-dlp-wrap').default)();
+        // Initialize yt-dlp-wrap
+        const ytDlp = new YTDlpWrap();
         
         // Extract subtitles using yt-dlp
         try {


### PR DESCRIPTION
## Summary
- replace CommonJS require of yt-dlp-wrap with direct YTDlpWrap instantiation
- maintain ES module import for YTDlpWrap

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check`
- `npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_689bc186ed1883298c3eb669620ca6f7