### PR TITLE
refactor: migrate summarization to OpenAI responses API

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -296,9 +296,9 @@ export async function registerRoutes(app: Express): Promise<Server> {
       // Process each chunk
       for (const chunk of chunks) {
         try {
-          const response = await openai.chat.completions.create({
+          const response = await openai.responses.create({
             model: "gpt-4o", // the newest OpenAI model is "gpt-4o" which was released May 13, 2024. do not change this unless explicitly requested by the user
-            messages: [
+            input: [
               {
                 role: "system",
                 content: `You are an expert at summarizing video transcripts. Create a clear, concise summary with the following format:
@@ -319,11 +319,11 @@ Keep each bullet point clear and informative. Respond in JSON format with "tldr"
                 content: `Please summarize this transcript chunk:\n\n${chunk}`
               }
             ],
-            response_format: { type: "json_object" },
+            text: { format: { type: "json_object" } },
             temperature: 0.3
           });
 
-          const result = JSON.parse(response.choices[0].message.content || '{}');
+          const result = JSON.parse(response.output_text || '{}');
           summaries.push(JSON.stringify(result));
         } catch (error: any) {
           console.error('OpenAI API error for chunk:', error);
@@ -343,9 +343,9 @@ Keep each bullet point clear and informative. Respond in JSON format with "tldr"
           const allTldrs = combinedSummaries.map(s => s.tldr).join(' ');
           const allBulletPoints = combinedSummaries.flatMap(s => s.bulletPoints || []);
 
-          const finalResponse = await openai.chat.completions.create({
+          const finalResponse = await openai.responses.create({
             model: "gpt-4o", // the newest OpenAI model is "gpt-4o" which was released May 13, 2024. do not change this unless explicitly requested by the user
-            messages: [
+            input: [
               {
                 role: "system",
                 content: `You are combining multiple summaries into one final summary. Create a coherent final summary that consolidates all the information.
@@ -365,11 +365,11 @@ TLDRs: ${allTldrs}
 All bullet points: ${allBulletPoints.map((point, i) => `${i + 1}. ${point}`).join('\n')}`
               }
             ],
-            response_format: { type: "json_object" },
+            text: { format: { type: "json_object" } },
             temperature: 0.3
           });
 
-          finalSummary = JSON.parse(finalResponse.choices[0].message.content || '{}');
+          finalSummary = JSON.parse(finalResponse.output_text || '{}');
         } catch (error: any) {
           console.error('Error combining summaries:', error);
           // Fallback: use first summary if combination fails


### PR DESCRIPTION
## Summary
- replace deprecated chat completions calls with `responses.create`
- request JSON output via `text.format` when summarizing transcript chunks

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689bc3a4087483298b250098e98ef368