### PR TITLE
Fix yt-dlp-wrap import in ESM server

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -9,7 +9,12 @@ import {
 } from "@shared/schema";
 import fetch from 'node-fetch';
 import OpenAI from "openai";
-import YTDlpWrap from "yt-dlp-wrap";
+import YTDlpWrapPkg from "yt-dlp-wrap";
+// yt-dlp-wrap is published as a CommonJS module that sets `exports.default`
+// rather than `module.exports`. When importing it from an ES module we get an
+// object with a nested `default` property, so extract the actual class
+// constructor here.
+const YTDlpWrap = (YTDlpWrapPkg as any).default;
 
 const openai = new OpenAI({ 
   apiKey: process.env.OPENAI_API_KEY || process.env.OPENAI_API_KEY_ENV_VAR || ""


### PR DESCRIPTION
## Summary
- fix `yt-dlp-wrap` import by extracting default export when using ES modules
- add explanatory comments

## Testing
- `npm run check`
- `npm test` *(fails: Missing script "test")*
- `curl -s -o - -w '\n%{http_code}\n' -H 'Content-Type: application/json' -d '{"url":"https://www.youtube.com/watch?v=yPmMuzdXqRc"}' http://localhost:5000/api/transcript`


------
https://chatgpt.com/codex/tasks/task_e_689bc9866fc48329bc15c8271fc51f71