### PR TITLE
Use youtube-transcript-api for transcripts

### DIFF
--- a/server/fetch_transcript.py
+++ b/server/fetch_transcript.py
@@ -1,0 +1,27 @@
+import sys
+import json
+from youtube_transcript_api import YouTubeTranscriptApi
+
+def main():
+    if len(sys.argv) < 2:
+        print('[]')
+        return
+    video_id = sys.argv[1]
+    try:
+        ytt_api = YouTubeTranscriptApi()
+        transcript = ytt_api.fetch(video_id)
+        segments = [
+            {
+                "text": t.get("text", ""),
+                "offset": int(t.get("start", 0) * 1000),
+                "duration": int(t.get("duration", 0) * 1000),
+            }
+            for t in transcript
+        ]
+        print(json.dumps(segments))
+    except Exception as e:
+        print(json.dumps({"error": str(e)}), file=sys.stderr)
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- replace yt-dlp subtitle extraction with youtube-transcript-api via a Python helper
- spawn the helper from the transcript route to retrieve and process segments

## Testing
- `npm run check`
- `python3 server/fetch_transcript.py dQw4w9WgXcQ` *(fails: ProxyError('Unable to connect to proxy', OSError('Tunnel connection failed: 403 Forbidden')))*

------
https://chatgpt.com/codex/tasks/task_e_689bcb7088848329b45b95175b85f5cf