### PR TITLE
feat: add tokenizer-based chunking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@dqbd/tiktoken": "^1.0.22",
         "@hookform/resolvers": "^3.10.0",
         "@jridgewell/trace-mapping": "^0.3.25",
         "@neondatabase/serverless": "^0.10.4",
@@ -408,6 +409,12 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@dqbd/tiktoken": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/@dqbd/tiktoken/-/tiktoken-1.0.22.tgz",
+      "integrity": "sha512-RYhO8xeHkMNX5Ixqf4M1Ve3siCYJY/dI0yLnlX4M4oIEDOvjMIQ+E+3OUpAaZcWTaMtQJzGcDAghYfllpx3i/w==",
+      "license": "MIT"
     },
     "node_modules/@drizzle-team/brocli": {
       "version": "0.10.2",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "db:push": "drizzle-kit push"
   },
   "dependencies": {
+    "@dqbd/tiktoken": "^1.0.22",
     "@hookform/resolvers": "^3.10.0",
     "@jridgewell/trace-mapping": "^0.3.25",
     "@neondatabase/serverless": "^0.10.4",


### PR DESCRIPTION
## Summary
- use tiktoken for accurate token counts
- chunk transcripts based on token limits

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689cb5e6c258832987ccef459a9b313a