### PR TITLE
Fix YouTube transcript parsing

### DIFF
--- a/server/fetch_transcript.py
+++ b/server/fetch_transcript.py
@@ -12,9 +12,9 @@ def main():
         transcript = ytt_api.fetch(video_id)
         segments = [
             {
-                "text": t.get("text", ""),
-                "offset": int(t.get("start", 0) * 1000),
-                "duration": int(t.get("duration", 0) * 1000),
+                "text": t.text,
+                "offset": int(t.start * 1000),
+                "duration": int(t.duration * 1000),
             }
             for t in transcript
         ]


### PR DESCRIPTION
## Summary
- fix YouTube transcript fetching by using attribute access for transcript fields

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run check`
- `python3 server/fetch_transcript.py dQw4w9WgXcQ` (fails: HTTPSConnectionPool host 'www.youtube.com' 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_689ccc1386688329a2ca05ef60a9aedf